### PR TITLE
Fix for Nova 4 in Authorize

### DIFF
--- a/src/Http/Middleware/Authorize.php
+++ b/src/Http/Middleware/Authorize.php
@@ -3,7 +3,7 @@
 use Closure;
 use GeneaLabs\NovaHorizon\NovaHorizon;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response;
 use Laravel\Nova\Nova;
 use Laravel\Nova\Tool;
 


### PR DESCRIPTION
Allow both Response and JsonResponse in Authorize.php

(`GeneaLabs\NovaHorizon\Http\Middleware\Authorize::handle(): Return value must be of type Illuminate\Http\Response, Illuminate\Http\JsonResponse returned`)

Fixes #10